### PR TITLE
Renamed restriction methods, added where restrictions interface

### DIFF
--- a/src/main/java/be/shad/tsqb/hql/HqlQuery.java
+++ b/src/main/java/be/shad/tsqb/hql/HqlQuery.java
@@ -110,8 +110,10 @@ public class HqlQuery implements HqlQueryValue {
         return getSelect() + getFrom() + getWhere() + getGroupBy() + getOrderBy();
     }
 
-    @Override
-    public String toString() {
+    /**
+     * String with newlines and spaces to outline the query in a pretty format.
+     */
+    public String toFormattedString() {
         String str = getHql().
                 replace("select", "\nselect").
                 replace("from", "\nfrom").
@@ -137,6 +139,11 @@ public class HqlQuery implements HqlQueryValue {
             }
         }
         return format + "\n --- with params: " + params;
+    }
+    
+    @Override
+    public String toString() {
+        return getHql() + " --- with params: " + params;
     }
     
 }

--- a/src/main/java/be/shad/tsqb/joins/TypeSafeQueryJoin.java
+++ b/src/main/java/be/shad/tsqb/joins/TypeSafeQueryJoin.java
@@ -1,11 +1,18 @@
 package be.shad.tsqb.joins;
 
+import java.util.Date;
+
 import be.shad.tsqb.data.TypeSafeQueryProxyData;
 import be.shad.tsqb.query.TypeSafeQueryInternal;
+import be.shad.tsqb.restrictions.OnGoingBooleanRestriction;
+import be.shad.tsqb.restrictions.OnGoingDateRestriction;
+import be.shad.tsqb.restrictions.OnGoingEnumRestriction;
 import be.shad.tsqb.restrictions.OnGoingNumberRestriction;
 import be.shad.tsqb.restrictions.OnGoingTextRestriction;
+import be.shad.tsqb.restrictions.Restriction;
 import be.shad.tsqb.restrictions.RestrictionChainable;
 import be.shad.tsqb.restrictions.RestrictionsGroup;
+import be.shad.tsqb.restrictions.RestrictionsGroupImpl;
 import be.shad.tsqb.values.TypeSafeValue;
 
 /**
@@ -16,7 +23,7 @@ public class TypeSafeQueryJoin<T> {
     private final RestrictionsGroup restrictions;
 
     public TypeSafeQueryJoin(TypeSafeQueryInternal query, TypeSafeQueryProxyData data) {
-        this.restrictions = new RestrictionsGroup(query, data);
+        this.restrictions = new RestrictionsGroupImpl(query, data);
         this.data = data;
     }
     
@@ -29,8 +36,8 @@ public class TypeSafeQueryJoin<T> {
         return data;
     }
     
-    public RestrictionsGroup getRestrictions() {
-        return restrictions;
+    public Restriction getRestrictions() {
+        return restrictions.getRestrictions();
     }
     
     /**
@@ -40,35 +47,77 @@ public class TypeSafeQueryJoin<T> {
      * methods, but the result would be the same as calling with().and(...).
      */
     public RestrictionChainable with() {
-        return restrictions;
+        return restrictions.getRestrictions();
     }
 
     /**
      * Delegate to restrictions.
      */
     public OnGoingNumberRestriction with(Number value) {
-        return restrictions.and(value);
+        return with().and(value);
     }
 
     /**
      * Delegate to restrictions.
      */
     public OnGoingTextRestriction with(String value) {
-        return restrictions.and(value);
+        return with().and(value);
+    }
+    
+    /**
+     * Delegate to restrictions.
+     */
+    public OnGoingBooleanRestriction with(Boolean value) {
+        return with().and(value);
+    }
+    
+    /**
+     * Delegate to restrictions.
+     */
+    public OnGoingDateRestriction with(Date value) {
+        return with().and(value);
+    }
+    
+    /**
+     * Delegate to restrictions.
+     */
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> with(E value) {
+        return with().and(value);
     }
 
     /**
      * Delegate to restrictions.
      */
-    public OnGoingNumberRestriction withn(TypeSafeValue<Number> value) {
-        return restrictions.andn(value);
+    public OnGoingNumberRestriction withNumber(TypeSafeValue<Number> value) {
+        return with().andNumber(value);
     }
 
     /**
      * Delegate to restrictions.
      */
-    public OnGoingTextRestriction witht(TypeSafeValue<String> value) {
-        return restrictions.andt(value);
+    public OnGoingTextRestriction withString(TypeSafeValue<String> value) {
+        return with().andString(value);
     }
 
+    /**
+     * Delegate to restrictions.
+     */
+    public OnGoingDateRestriction withDate(TypeSafeValue<Date> value) {
+        return with().andDate(value);
+    }
+
+    /**
+     * Delegate to restrictions.
+     */
+    public OnGoingBooleanRestriction withBoolean(TypeSafeValue<Boolean> value) {
+        return with().andBoolean(value);
+    }
+
+    /**
+     * Delegate to restrictions.
+     */
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> withEnum(TypeSafeValue<E> value) {
+        return with().andEnum(value);
+    }
+    
 }

--- a/src/main/java/be/shad/tsqb/query/AbstractTypeSafeQuery.java
+++ b/src/main/java/be/shad/tsqb/query/AbstractTypeSafeQuery.java
@@ -20,8 +20,11 @@ import be.shad.tsqb.restrictions.OnGoingDateRestriction;
 import be.shad.tsqb.restrictions.OnGoingEnumRestriction;
 import be.shad.tsqb.restrictions.OnGoingNumberRestriction;
 import be.shad.tsqb.restrictions.OnGoingTextRestriction;
+import be.shad.tsqb.restrictions.Restriction;
 import be.shad.tsqb.restrictions.RestrictionChainable;
 import be.shad.tsqb.restrictions.RestrictionsGroup;
+import be.shad.tsqb.restrictions.RestrictionsGroupImpl;
+import be.shad.tsqb.restrictions.RestrictionsGroupInternal;
 import be.shad.tsqb.selection.TypeSafeQueryProjections;
 import be.shad.tsqb.values.DirectTypeSafeValue;
 import be.shad.tsqb.values.HqlQueryValue;
@@ -38,7 +41,7 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
 
     private final TypeSafeQueryProxyDataTree dataTree;
     private final TypeSafeQueryProjections projections = new TypeSafeQueryProjections(this); 
-    private final RestrictionsGroup restrictions = new RestrictionsGroup(this, null); 
+    private final RestrictionsGroupInternal restrictions = new RestrictionsGroupImpl(this, null); 
     private final TypeSafeQueryGroupBys groupBys = new TypeSafeQueryGroupBys(this);
     private final TypeSafeQueryOrderBys orderBys = new TypeSafeQueryOrderBys(this);
     
@@ -152,6 +155,30 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
      * {@inheritDoc}
      */
     @Override
+    public RestrictionChainable where(RestrictionsGroup group) {
+        return restrictions.and(group.getRestrictions());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Restriction where(Restriction restriction) {
+        return restrictions.and(restriction);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RestrictionsGroup whereGroup() {
+        return new RestrictionsGroupImpl(this, null);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public RestrictionChainable whereExists(TypeSafeSubQuery<?> subquery) {
         return restrictions.andExists(subquery);
     }
@@ -168,8 +195,8 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
      * Delegate to restrictions.
      */
     @Override
-    public <E extends Enum<E>> OnGoingEnumRestriction<E> wheree(TypeSafeValue<E> value) {
-        return restrictions.ande(value);
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> whereEnum(TypeSafeValue<E> value) {
+        return restrictions.andEnum(value);
     }
     
     /**
@@ -184,8 +211,8 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
      * Delegate to restrictions.
      */
     @Override
-    public OnGoingBooleanRestriction whereb(TypeSafeValue<Boolean> value) {
-        return restrictions.andb(value);
+    public OnGoingBooleanRestriction whereBoolean(TypeSafeValue<Boolean> value) {
+        return restrictions.andBoolean(value);
     }
     
     /**
@@ -208,16 +235,16 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
      * Delegate to restrictions.
      */
     @Override
-    public OnGoingNumberRestriction wheren(TypeSafeValue<Number> value) {
-        return restrictions.andn(value);
+    public OnGoingNumberRestriction whereNumber(TypeSafeValue<Number> value) {
+        return restrictions.andNumber(value);
     }
 
     /**
      * Delegate to restrictions.
      */
     @Override
-    public OnGoingTextRestriction wheret(TypeSafeValue<String> value) {
-        return restrictions.andt(value);
+    public OnGoingTextRestriction whereString(TypeSafeValue<String> value) {
+        return restrictions.andString(value);
     }
     
     /**
@@ -232,8 +259,8 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
      * Delegate to restrictions.
      */
     @Override
-    public OnGoingDateRestriction whered(TypeSafeValue<Date> value) {
-        return restrictions.andd(value);
+    public OnGoingDateRestriction whereDate(TypeSafeValue<Date> value) {
+        return restrictions.andDate(value);
     }
     
     /**

--- a/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
+++ b/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
@@ -8,12 +8,9 @@ import be.shad.tsqb.helper.TypeSafeQueryHelper;
 import be.shad.tsqb.hql.HqlQuery;
 import be.shad.tsqb.joins.TypeSafeQueryJoin;
 import be.shad.tsqb.ordering.OnGoingOrderBy;
-import be.shad.tsqb.restrictions.OnGoingBooleanRestriction;
-import be.shad.tsqb.restrictions.OnGoingDateRestriction;
-import be.shad.tsqb.restrictions.OnGoingEnumRestriction;
-import be.shad.tsqb.restrictions.OnGoingNumberRestriction;
-import be.shad.tsqb.restrictions.OnGoingTextRestriction;
 import be.shad.tsqb.restrictions.RestrictionChainable;
+import be.shad.tsqb.restrictions.RestrictionsGroup;
+import be.shad.tsqb.restrictions.WhereRestrictions;
 import be.shad.tsqb.values.TypeSafeValue;
 import be.shad.tsqb.values.TypeSafeValueFunctions;
 
@@ -42,7 +39,7 @@ import be.shad.tsqb.values.TypeSafeValueFunctions;
  * <p>
  * For an example, see {@link TypeSafeRootQuery}.
  */
-public interface TypeSafeQuery {
+public interface TypeSafeQuery extends WhereRestrictions {
     
     /**
      * Creates a proxy for the given fromClass.
@@ -86,74 +83,17 @@ public interface TypeSafeQuery {
      * @throws IllegalArgumentException if the object is not an entity proxy.
      */
     <T> TypeSafeQueryJoin<T> getJoin(T obj);
-    
-    RestrictionChainable where();
 
     /**
-     * The general restrict by enum method. Anything which represents a number
-     * can be used with this method.
+     * Creates a subgroup for this query. This group is not added to the query
+     * where until it is added using the {@link RestrictionChainable#and(be.shad.tsqb.restrictions.Restriction) and(restriction)} 
+     * or the {@link RestrictionChainable#or(be.shad.tsqb.restrictions.Restriction) or(restriction)}.
+     * <p>
+     * The group will not be added to the existing restrictions automatically.
+     * This must be done separately.
      */
-    <E extends Enum<E>> OnGoingEnumRestriction<E> wheree(TypeSafeValue<E> value);
+    RestrictionsGroup whereGroup();
 
-    /**
-     * Restrict an enum value. This can be a direct value (an actual enum value),
-     * or a value of a TypeSafeQueryProxy getter.
-     */
-    <E extends Enum<E>> OnGoingEnumRestriction<E> where(E value);
-    
-    /**
-     * The general restrict by boolean method. Anything which represents a boolean
-     * can be used with this method.
-     */
-    OnGoingBooleanRestriction whereb(TypeSafeValue<Boolean> value);
-
-    /**
-     * Restrict a boolean value. This can be a direct value (an actual boolean),
-     * or a value of a TypeSafeQueryProxy getter. 
-     */
-    OnGoingBooleanRestriction where(Boolean value);
-
-    /**
-     * The general restrict by number method. Anything which represents a number
-     * can be used with this method.
-     */
-    OnGoingNumberRestriction wheren(TypeSafeValue<Number> value);
-
-    /**
-     * Restrict a number value. This can be a direct value (an actual number),
-     * or a value of a TypeSafeQueryProxy getter. 
-     */
-    OnGoingNumberRestriction where(Number value);
-
-    /**
-     * The general restrict by date method. Anything which represents a date
-     * can be used with this method.
-     */
-    OnGoingDateRestriction whered(TypeSafeValue<Date> value);
-
-    /**
-     * Restrict a number value. This can be a direct value (an actual date),
-     * or a value of a TypeSafeQueryProxy getter. 
-     */
-    OnGoingDateRestriction where(Date value);
-
-    /**
-     * The general restrict by string method. Anything which represents a string
-     * can be used with this method.
-     */
-    OnGoingTextRestriction wheret(TypeSafeValue<String> value);
-
-    /**
-     * Restrict a string value. This can be a direct value (an actual string),
-     * or a value of a TypeSafeQueryProxy getter. 
-     */
-    OnGoingTextRestriction where(String value);
-
-    /**
-     * Adds an exists restriction.
-     */
-    RestrictionChainable whereExists(TypeSafeSubQuery<?> subquery);
-    
     /**
      * Get the orderBy, allowing to add descending and ascending order bys.
      */

--- a/src/main/java/be/shad/tsqb/restrictions/OnGoingBooleanRestriction.java
+++ b/src/main/java/be/shad/tsqb/restrictions/OnGoingBooleanRestriction.java
@@ -1,6 +1,10 @@
 package be.shad.tsqb.restrictions;
 
 import static be.shad.tsqb.restrictions.RestrictionImpl.EQUAL;
+
+import java.util.Date;
+
+import be.shad.tsqb.query.TypeSafeSubQuery;
 import be.shad.tsqb.values.DirectTypeSafeValue;
 import be.shad.tsqb.values.TypeSafeValue;
 
@@ -9,7 +13,7 @@ import be.shad.tsqb.values.TypeSafeValue;
  * 
  * @see OnGoingRestriction
  */
-public class OnGoingBooleanRestriction extends OnGoingRestriction<Boolean> {
+public class OnGoingBooleanRestriction extends OnGoingRestriction<Boolean> implements RestrictionChainable {
 
     public OnGoingBooleanRestriction(RestrictionImpl restriction, Boolean argument) {
         super(restriction, argument);
@@ -35,6 +39,116 @@ public class OnGoingBooleanRestriction extends OnGoingRestriction<Boolean> {
         restriction.setOperator(EQUAL);
         restriction.setRight(new DirectTypeSafeValue<>(restriction.getQuery(), Boolean.TRUE));
         return restriction;
+    }
+
+    @Override
+    public RestrictionChainable andExists(TypeSafeSubQuery<?> subquery) {
+        return isTrue().andExists(subquery);
+    }
+
+    @Override
+    public RestrictionChainable orExists(TypeSafeSubQuery<?> subquery) {
+        return isTrue().orExists(subquery);
+    }
+
+    @Override
+    public Restriction and(Restriction restriction) {
+        return isTrue().and(restriction);
+    }
+
+    @Override
+    public Restriction or(Restriction restriction) {
+        return isTrue().or(restriction);
+    }
+
+    @Override
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> andEnum(TypeSafeValue<E> value) {
+        return isTrue().andEnum(value);
+    }
+
+    @Override
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> and(E value) {
+        return isTrue().and(value);
+    }
+
+    @Override
+    public OnGoingBooleanRestriction andBoolean(TypeSafeValue<Boolean> value) {
+        return isTrue().andBoolean(value);
+    }
+
+    @Override
+    public OnGoingBooleanRestriction and(Boolean value) {
+        return isTrue().and(value);
+    }
+
+    @Override
+    public OnGoingNumberRestriction andNumber(TypeSafeValue<Number> value) {
+        return isTrue().andNumber(value);
+    }
+
+    @Override
+    public OnGoingNumberRestriction and(Number value) {
+        return isTrue().and(value);
+    }
+
+    @Override
+    public OnGoingDateRestriction andDate(TypeSafeValue<Date> value) {
+        return isTrue().andDate(value);
+    }
+
+    @Override
+    public OnGoingDateRestriction and(Date value) {
+        return isTrue().and(value);
+    }
+
+    @Override
+    public OnGoingTextRestriction andString(TypeSafeValue<String> value) {
+        return isTrue().andString(value);
+    }
+
+    @Override
+    public OnGoingTextRestriction and(String value) {
+        return isTrue().and(value);
+    }
+
+    @Override
+    public OnGoingDateRestriction or(Date value) {
+        return isTrue().or(value);
+    }
+
+    @Override
+    public OnGoingDateRestriction orDate(TypeSafeValue<Date> value) {
+        return isTrue().orDate(value);
+    }
+
+    @Override
+    public OnGoingBooleanRestriction or(Boolean value) {
+        return isTrue().or(value);
+    }
+
+    @Override
+    public OnGoingBooleanRestriction orBoolean(TypeSafeValue<Boolean> value) {
+        return isTrue().orBoolean(value);
+    }
+
+    @Override
+    public OnGoingNumberRestriction orNumber(TypeSafeValue<Number> value) {
+        return isTrue().orNumber(value);
+    }
+
+    @Override
+    public OnGoingNumberRestriction or(Number value) {
+        return isTrue().or(value);
+    }
+
+    @Override
+    public OnGoingTextRestriction orString(TypeSafeValue<String> value) {
+        return isTrue().orString(value);
+    }
+
+    @Override
+    public OnGoingTextRestriction or(String value) {
+        return isTrue().or(value);
     }
     
 }

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionChainable.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionChainable.java
@@ -33,7 +33,7 @@ public interface RestrictionChainable {
      * The general restrict by enum method. Anything which represents a number
      * can be used with this method.
      */
-    <E extends Enum<E>> OnGoingEnumRestriction<E> ande(TypeSafeValue<E> value);
+    <E extends Enum<E>> OnGoingEnumRestriction<E> andEnum(TypeSafeValue<E> value);
 
     /**
      * Restrict an enum value. This can be a direct value (an actual enum value),
@@ -45,7 +45,7 @@ public interface RestrictionChainable {
      * The general restrict by number method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingBooleanRestriction andb(TypeSafeValue<Boolean> value);
+    OnGoingBooleanRestriction andBoolean(TypeSafeValue<Boolean> value);
 
     /**
      * Restrict a number value. This can be a direct value (an actual string),
@@ -57,7 +57,7 @@ public interface RestrictionChainable {
      * The general restrict by number method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingNumberRestriction andn(TypeSafeValue<Number> value);
+    OnGoingNumberRestriction andNumber(TypeSafeValue<Number> value);
 
     /**
      * Restrict a number value. This can be a direct value (an actual string),
@@ -69,7 +69,7 @@ public interface RestrictionChainable {
      * The general restrict by date method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingDateRestriction andd(TypeSafeValue<Date> value);
+    OnGoingDateRestriction andDate(TypeSafeValue<Date> value);
 
     /**
      * Restrict a number value. This can be a direct value (an actual string),
@@ -81,7 +81,7 @@ public interface RestrictionChainable {
      * The general restrict by number method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingTextRestriction andt(TypeSafeValue<String> value);
+    OnGoingTextRestriction andString(TypeSafeValue<String> value);
 
     /**
      * Restrict a string value. This can be a direct value (an actual string),
@@ -99,7 +99,7 @@ public interface RestrictionChainable {
      * The general restrict by date method. Anything which represents a date
      * can be used with this method.
      */
-    OnGoingDateRestriction ord(TypeSafeValue<Date> value);
+    OnGoingDateRestriction orDate(TypeSafeValue<Date> value);
     
     /**
      * Restrict a boolean value. This can be a direct value (an actual boolean),
@@ -111,13 +111,13 @@ public interface RestrictionChainable {
      * The general restrict by boolean method. Anything which represents a boolean
      * can be used with this method.
      */
-    OnGoingBooleanRestriction orb(TypeSafeValue<Boolean> value);
+    OnGoingBooleanRestriction orBoolean(TypeSafeValue<Boolean> value);
     
     /**
      * The general restrict by number method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingNumberRestriction orn(TypeSafeValue<Number> value);
+    OnGoingNumberRestriction orNumber(TypeSafeValue<Number> value);
 
     /**
      * Restrict a number value. This can be a direct value (an actual number),
@@ -129,7 +129,7 @@ public interface RestrictionChainable {
      * The general restrict by number method. Anything which represents a number
      * can be used with this method.
      */
-    OnGoingTextRestriction ort(TypeSafeValue<String> value);
+    OnGoingTextRestriction orString(TypeSafeValue<String> value);
 
     /**
      * Restrict a string value. This can be a direct value (an actual string),

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionChainableImpl.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionChainableImpl.java
@@ -48,7 +48,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public <E extends Enum<E>> OnGoingEnumRestriction<E> ande(TypeSafeValue<E> value) {
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> andEnum(TypeSafeValue<E> value) {
         return new OnGoingEnumRestriction<E>(and(), value);
     }
 
@@ -64,7 +64,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingTextRestriction andt(TypeSafeValue<String> value) {
+    public OnGoingTextRestriction andString(TypeSafeValue<String> value) {
         return new OnGoingTextRestriction(and(), value);
     }
 
@@ -80,7 +80,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingBooleanRestriction andb(TypeSafeValue<Boolean> value) {
+    public OnGoingBooleanRestriction andBoolean(TypeSafeValue<Boolean> value) {
         return new OnGoingBooleanRestriction(and(), value);
     }
 
@@ -96,7 +96,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingNumberRestriction andn(TypeSafeValue<Number> value) {
+    public OnGoingNumberRestriction andNumber(TypeSafeValue<Number> value) {
         return new OnGoingNumberRestriction(and(), value);
     }
 
@@ -112,7 +112,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingDateRestriction andd(TypeSafeValue<Date> value) {
+    public OnGoingDateRestriction andDate(TypeSafeValue<Date> value) {
         return new OnGoingDateRestriction(and(), value);
     }
 
@@ -128,7 +128,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingTextRestriction ort(TypeSafeValue<String> value) {
+    public OnGoingTextRestriction orString(TypeSafeValue<String> value) {
         return new OnGoingTextRestriction(or(), value);
     }
 
@@ -144,7 +144,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingNumberRestriction orn(TypeSafeValue<Number> value) {
+    public OnGoingNumberRestriction orNumber(TypeSafeValue<Number> value) {
         return new OnGoingNumberRestriction(or(), value);
     }
     
@@ -168,7 +168,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingBooleanRestriction orb(TypeSafeValue<Boolean> value) {
+    public OnGoingBooleanRestriction orBoolean(TypeSafeValue<Boolean> value) {
         return new OnGoingBooleanRestriction(or(), value);
     }
 
@@ -176,7 +176,7 @@ public abstract class RestrictionChainableImpl implements RestrictionChainable, 
      * {@inheritDoc}
      */
     @Override
-    public OnGoingDateRestriction ord(TypeSafeValue<Date> value) {
+    public OnGoingDateRestriction orDate(TypeSafeValue<Date> value) {
         return new OnGoingDateRestriction(or(), value);
     }
     

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionImpl.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionImpl.java
@@ -28,7 +28,7 @@ public class RestrictionImpl extends RestrictionChainableImpl implements Restric
     public final static String IS_NOT_NULL = "is not null";
     public final static String EXISTS = "exists";
     
-    private final RestrictionsGroup group;
+    private final RestrictionsGroupImpl group;
     private final TypeSafeQueryInternal query;
     
     private TypeSafeValue<?> left;
@@ -36,7 +36,7 @@ public class RestrictionImpl extends RestrictionChainableImpl implements Restric
     private TypeSafeValue<?> right;
     
     public RestrictionImpl(TypeSafeQueryInternal query, 
-            RestrictionsGroup restrictions) {
+            RestrictionsGroupImpl restrictions) {
         this.group = restrictions;
         this.query = query;
     }

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionWrapper.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionWrapper.java
@@ -7,10 +7,10 @@ import be.shad.tsqb.values.HqlQueryValueImpl;
  * Wraps a restriction in brackets.
  */
 public class RestrictionWrapper extends RestrictionChainableImpl implements Restriction {
-    private final RestrictionsGroup group;
+    private final RestrictionsGroupImpl group;
     private final Restriction restriction;
     
-    public RestrictionWrapper(RestrictionsGroup group,
+    public RestrictionWrapper(RestrictionsGroupImpl group,
             Restriction restriction) {
         this.restriction = restriction;
         this.group = group;
@@ -43,7 +43,7 @@ public class RestrictionWrapper extends RestrictionChainableImpl implements Rest
     }
 
     @Override
-    public RestrictionsGroup getRestrictionsGroup() {
+    public RestrictionsGroupImpl getRestrictionsGroup() {
         return group;
     }
 

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroup.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroup.java
@@ -1,151 +1,23 @@
 package be.shad.tsqb.restrictions;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import be.shad.tsqb.data.TypeSafeQueryProxyData;
-import be.shad.tsqb.query.TypeSafeQuery;
-import be.shad.tsqb.query.TypeSafeQueryInternal;
-import be.shad.tsqb.values.HqlQueryValue;
-import be.shad.tsqb.values.HqlQueryValueBuilder;
-import be.shad.tsqb.values.HqlQueryValueImpl;
 
 /**
- * Groups restrictions, either to restrict the where clause of a query or to restrict the with clause of a join.
- * <p>
- * A restriction group may be nested, to group a sequence of 'ors' in one part of a query for example.
+ * Groups the Restriction and WhereRestrictions to be able to add a group
+ * as a nested restriction group and to provide the where() methods to start
+ * chaining.
  */
-public class RestrictionsGroup extends RestrictionChainableImpl implements RestrictionChainable, RestrictionProvider, Restriction, HqlQueryValueBuilder {
-    private final TypeSafeQueryInternal query;
-    private final TypeSafeQueryProxyData join;
-    private List<RestrictionNode> restrictions;
-    
-    public RestrictionsGroup(TypeSafeQueryInternal query,
-            TypeSafeQueryProxyData join) {
-        this.query = query;
-        this.join = join;
-        this.restrictions = new ArrayList<>();
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public RestrictionsGroup getRestrictionsGroup() {
-        return this;
-    }
-    
-    /**
-     * Creates a new group which is used to restrict the where part of a query.
-     */
-    public static RestrictionsGroup group(TypeSafeQuery query) {
-        return group(query, null);
-    }
+public interface RestrictionsGroup extends WhereRestrictions {
 
     /**
-     * Creates a new group which is used to restrict the with part of a join.
-     * The join data is kept in order to be able to validate if the used values are in scope.
-     */
-    public static RestrictionsGroup group(TypeSafeQuery query, TypeSafeQueryProxyData join) {
-        return new RestrictionsGroup((TypeSafeQueryInternal) query, join);
-    }
-    
-    /**
-     * The joined entity proxy data, might be null if this group is not used in a with (restrictions) clause.
-     */
-    public TypeSafeQueryProxyData getJoin() {
-        return join;
-    }
-    
-    /**
-     * Loops the restrictions and links them together with ands and ors.
-     */
-    @Override
-    public HqlQueryValueImpl toHqlQueryValue() {
-        HqlQueryValueImpl value = new HqlQueryValueImpl();
-        for(RestrictionNode item: restrictions) {
-            HqlQueryValue nextValue = item.getRestriction().toHqlQueryValue();
-            if( item.getType() == RestrictionNodeType.And ) {
-                value.appendHql(" and ");
-            } else if( item.getType() == RestrictionNodeType.Or ) {
-                value.appendHql(" or ");
-            } // else null, root
-            value.appendHql(nextValue.getHql());
-            value.addParams(nextValue.getParams());
-        }
-        return value;
-    }
-    
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder("Restrictions [");
-        for(RestrictionNode item: restrictions) {
-            sb.append("\n").append(item.getRestriction());
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public Restriction and(Restriction restriction) {
-        return add(restriction, RestrictionNodeType.And);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public Restriction or(Restriction restriction) {
-        return add(restriction, RestrictionNodeType.Or);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public RestrictionImpl and() {
-        return add(RestrictionNodeType.And);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public RestrictionImpl or() {
-        return add(RestrictionNodeType.Or);
-    }
-
-    /**
-     * Creates the restrictions and adds it to the chain, with the given <code>type</code>.
-     */
-    private RestrictionImpl add(RestrictionNodeType type) {
-        RestrictionImpl next = new RestrictionImpl(query, this);
-        return (RestrictionImpl) add(next, type);
-    }
-    
-    /**
-     * Wraps the restriction in a group if its group was different.
-     * This happens when a group was created to group 'ors' for example,
-     * and this group is added to this group to add it to the query restrictions.
+     * The RestrictionsGroup doesn't implement the Restriction itself
+     * because this would add the RestrictionChainable methods to this interface.
      * <p>
-     * Example:
-     * <pre>
-     * Person person = query.from(Person.class);
-     *  query.where(person.isMarried()).isTrue().
-     *          and(RestrictionsGroup.group(query).
-     *              and(person.getName()).startsWith("Jef").
-     *               or(person.getName()).startsWith("John"));
-     * </pre>
-     * The RestrictionsGroup is created, and restrictions are added using the chaining methods.
-     * At the end, when all the chaining finishes, the last restriction of the chain is returned
-     * and add to this group. At this point it is detected that the restriction was part
-     * of a sub-group because its restriction group is different.
+     * To be able to separately build a group, and then add it to the
+     * query, use this method to get this group as a Restriction.
+     * <p>
+     * Usually, the restriction group is built as a chainable and the
+     * final return value will already be a restriction.
      */
-    private Restriction add(Restriction restriction, RestrictionNodeType type) {
-        if( restriction.getRestrictionsGroup() != this ) {
-            restriction = new RestrictionWrapper(this, restriction.getRestrictionsGroup());
-        }
-        restrictions.add(new RestrictionNode(restriction, restrictions.isEmpty() ? null: type));
-        return restriction;
-    }
+    Restriction getRestrictions();
 
 }

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroupImpl.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroupImpl.java
@@ -1,0 +1,268 @@
+package be.shad.tsqb.restrictions;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import be.shad.tsqb.data.TypeSafeQueryProxyData;
+import be.shad.tsqb.query.TypeSafeQuery;
+import be.shad.tsqb.query.TypeSafeQueryInternal;
+import be.shad.tsqb.query.TypeSafeSubQuery;
+import be.shad.tsqb.values.HqlQueryValue;
+import be.shad.tsqb.values.HqlQueryValueBuilder;
+import be.shad.tsqb.values.HqlQueryValueImpl;
+import be.shad.tsqb.values.TypeSafeValue;
+
+/**
+ * Groups restrictions, either to restrict the where clause of a query or to restrict the with clause of a join.
+ * <p>
+ * A restriction group may be nested, to group a sequence of 'ors' in one part of a query for example.
+ */
+public class RestrictionsGroupImpl extends RestrictionChainableImpl implements RestrictionProvider, Restriction, RestrictionsGroupInternal, HqlQueryValueBuilder {
+    private final TypeSafeQueryInternal query;
+    private final TypeSafeQueryProxyData join;
+    private List<RestrictionNode> restrictions;
+    
+    public RestrictionsGroupImpl(TypeSafeQueryInternal query,
+            TypeSafeQueryProxyData join) {
+        this.query = query;
+        this.join = join;
+        this.restrictions = new ArrayList<>();
+    }
+    
+    @Override
+    public RestrictionChainable where(RestrictionsGroup group) {
+        return and(group.getRestrictions());
+    }
+    
+    @Override
+    public Restriction where(Restriction restriction) {
+        return and(restriction);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RestrictionsGroupImpl getRestrictionsGroup() {
+        return this;
+    }
+    
+    /**
+     * Creates a new group which is used to restrict the where part of a query.
+     */
+    public static RestrictionsGroupImpl group(TypeSafeQuery query) {
+        return group(query, null);
+    }
+
+    /**
+     * Creates a new group which is used to restrict the with part of a join.
+     * The join data is kept in order to be able to validate if the used values are in scope.
+     */
+    public static RestrictionsGroupImpl group(TypeSafeQuery query, TypeSafeQueryProxyData join) {
+        return new RestrictionsGroupImpl((TypeSafeQueryInternal) query, join);
+    }
+    
+    /**
+     * The joined entity proxy data, might be null if this group is not used in a with (restrictions) clause.
+     */
+    public TypeSafeQueryProxyData getJoin() {
+        return join;
+    }
+    
+    /**
+     * Loops the restrictions and links them together with ands and ors.
+     */
+    @Override
+    public HqlQueryValueImpl toHqlQueryValue() {
+        HqlQueryValueImpl value = new HqlQueryValueImpl();
+        for(RestrictionNode item: restrictions) {
+            HqlQueryValue nextValue = item.getRestriction().toHqlQueryValue();
+            if( item.getType() == RestrictionNodeType.And ) {
+                value.appendHql(" and ");
+            } else if( item.getType() == RestrictionNodeType.Or ) {
+                value.appendHql(" or ");
+            } // else null, root
+            value.appendHql(nextValue.getHql());
+            value.addParams(nextValue.getParams());
+        }
+        return value;
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("Restrictions [");
+        for(RestrictionNode item: restrictions) {
+            sb.append("\n").append(item.getRestriction());
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RestrictionChainable where() {
+        return this;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Restriction and(Restriction restriction) {
+        return add(restriction, RestrictionNodeType.And);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Restriction or(Restriction restriction) {
+        return add(restriction, RestrictionNodeType.Or);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RestrictionImpl and() {
+        return add(RestrictionNodeType.And);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RestrictionImpl or() {
+        return add(RestrictionNodeType.Or);
+    }
+
+    /**
+     * Creates the restrictions and adds it to the chain, with the given <code>type</code>.
+     */
+    private RestrictionImpl add(RestrictionNodeType type) {
+        RestrictionImpl next = new RestrictionImpl(query, this);
+        return (RestrictionImpl) add(next, type);
+    }
+    
+    /**
+     * Wraps the restriction in a group if its group was different.
+     * This happens when a group was created to group 'ors' for example,
+     * and this group is added to this group to add it to the query restrictions.
+     * <p>
+     * Example:
+     * <pre>
+     * Person person = query.from(Person.class);
+     *  query.where(person.isMarried()).isTrue().
+     *          and(RestrictionsGroup.group(query).
+     *              and(person.getName()).startsWith("Jef").
+     *               or(person.getName()).startsWith("John"));
+     * </pre>
+     * The RestrictionsGroup is created, and restrictions are added using the chaining methods.
+     * At the end, when all the chaining finishes, the last restriction of the chain is returned
+     * and add to this group. At this point it is detected that the restriction was part
+     * of a sub-group because its restriction group is different.
+     */
+    private Restriction add(Restriction restriction, RestrictionNodeType type) {
+        if( restriction.getRestrictionsGroup() != this ) {
+            restriction = new RestrictionWrapper(this, restriction.getRestrictionsGroup().getRestrictions());
+        }
+        restrictions.add(new RestrictionNode(restriction, restrictions.isEmpty() ? null: type));
+        return restriction;
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> whereEnum(TypeSafeValue<E> value) {
+        return andEnum(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public <E extends Enum<E>> OnGoingEnumRestriction<E> where(E value) {
+        return and(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingBooleanRestriction whereBoolean(TypeSafeValue<Boolean> value) {
+        return andBoolean(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingBooleanRestriction where(Boolean value) {
+        return and(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingNumberRestriction whereNumber(TypeSafeValue<Number> value) {
+        return andNumber(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingNumberRestriction where(Number value) {
+        return and(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingDateRestriction whereDate(TypeSafeValue<Date> value) {
+        return andDate(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingDateRestriction where(Date value) {
+        return and(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingTextRestriction whereString(TypeSafeValue<String> value) {
+        return andString(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public OnGoingTextRestriction where(String value) {
+        return and(value);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public RestrictionChainable whereExists(TypeSafeSubQuery<?> subquery) {
+        return andExists(subquery);
+    }
+
+    /**
+     * Delegate the call to and().
+     */
+    @Override
+    public Restriction getRestrictions() {
+        return this;
+    }
+
+}

--- a/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroupInternal.java
+++ b/src/main/java/be/shad/tsqb/restrictions/RestrictionsGroupInternal.java
@@ -1,0 +1,16 @@
+package be.shad.tsqb.restrictions;
+
+import be.shad.tsqb.data.TypeSafeQueryProxyData;
+import be.shad.tsqb.values.HqlQueryValueBuilder;
+
+/**
+ * Extend to include extra interfaces
+ */
+public interface RestrictionsGroupInternal extends RestrictionsGroup, RestrictionProvider, RestrictionChainable, HqlQueryValueBuilder {
+
+    /**
+     * Get the join, for scope testing.
+     */
+    TypeSafeQueryProxyData getJoin();
+    
+}

--- a/src/main/java/be/shad/tsqb/restrictions/WhereRestrictions.java
+++ b/src/main/java/be/shad/tsqb/restrictions/WhereRestrictions.java
@@ -1,0 +1,92 @@
+package be.shad.tsqb.restrictions;
+
+import java.util.Date;
+
+import be.shad.tsqb.query.TypeSafeSubQuery;
+import be.shad.tsqb.values.TypeSafeValue;
+
+public interface WhereRestrictions {
+
+    /**
+     * In case part of the restrictions were already built, but no reference was kept
+     * to the last restriction chainable, this method can be used to get the last
+     * one to be able to continue with 'or' on an already partially built restrictions group.
+     */
+    RestrictionChainable where();
+
+    /**
+     * Adds a restriction group as and to the existing where clause.
+     */
+    RestrictionChainable where(RestrictionsGroup group);
+
+    /**
+     * Adds a restriction as and to the existing where clause.
+     */
+    Restriction where(Restriction restriction);
+    
+    /**
+     * The general restrict by enum method. Anything which represents a number
+     * can be used with this method.
+     */
+    <E extends Enum<E>> OnGoingEnumRestriction<E> whereEnum(TypeSafeValue<E> value);
+
+    /**
+     * Restrict an enum value. This can be a direct value (an actual enum value),
+     * or a value of a TypeSafeQueryProxy getter.
+     */
+    <E extends Enum<E>> OnGoingEnumRestriction<E> where(E value);
+    
+    /**
+     * The general restrict by boolean method. Anything which represents a boolean
+     * can be used with this method.
+     */
+    OnGoingBooleanRestriction whereBoolean(TypeSafeValue<Boolean> value);
+
+    /**
+     * Restrict a boolean value. This can be a direct value (an actual boolean),
+     * or a value of a TypeSafeQueryProxy getter. 
+     */
+    OnGoingBooleanRestriction where(Boolean value);
+
+    /**
+     * The general restrict by number method. Anything which represents a number
+     * can be used with this method.
+     */
+    OnGoingNumberRestriction whereNumber(TypeSafeValue<Number> value);
+
+    /**
+     * Restrict a number value. This can be a direct value (an actual number),
+     * or a value of a TypeSafeQueryProxy getter. 
+     */
+    OnGoingNumberRestriction where(Number value);
+
+    /**
+     * The general restrict by date method. Anything which represents a date
+     * can be used with this method.
+     */
+    OnGoingDateRestriction whereDate(TypeSafeValue<Date> value);
+
+    /**
+     * Restrict a number value. This can be a direct value (an actual date),
+     * or a value of a TypeSafeQueryProxy getter. 
+     */
+    OnGoingDateRestriction where(Date value);
+
+    /**
+     * The general restrict by string method. Anything which represents a string
+     * can be used with this method.
+     */
+    OnGoingTextRestriction whereString(TypeSafeValue<String> value);
+
+    /**
+     * Restrict a string value. This can be a direct value (an actual string),
+     * or a value of a TypeSafeQueryProxy getter. 
+     */
+    OnGoingTextRestriction where(String value);
+
+    /**
+     * Adds an exists restriction.
+     */
+    RestrictionChainable whereExists(TypeSafeSubQuery<?> subquery);
+    
+}

--- a/src/test/java/be/shad/tsqb/test/ExamplesTest.java
+++ b/src/test/java/be/shad/tsqb/test/ExamplesTest.java
@@ -10,7 +10,7 @@ import be.shad.tsqb.dto.PersonDto;
 import be.shad.tsqb.joins.TypeSafeQueryJoin;
 import be.shad.tsqb.query.JoinType;
 import be.shad.tsqb.query.TypeSafeSubQuery;
-import be.shad.tsqb.restrictions.RestrictionsGroup;
+import be.shad.tsqb.restrictions.RestrictionsGroupImpl;
 
 public class ExamplesTest extends TypeSafeQueryTest {
 
@@ -44,7 +44,7 @@ public class ExamplesTest extends TypeSafeQueryTest {
     public void testFilteringMore() {
         Person person = query.from(Person.class);
         
-        query.where(person.isMarried()).isTrue().  // type based checks available
+        query.where(person.isMarried()).  // type based checks available
                 and(person.getSex()).eq(Sex.Male); // can chain restrictions
 
         validate(" from Person hobj1 where hobj1.married = ? and hobj1.sex = ?", Boolean.TRUE, Sex.Male);
@@ -58,7 +58,7 @@ public class ExamplesTest extends TypeSafeQueryTest {
         Person person = query.from(Person.class);
         
         query.where(person.isMarried()).isTrue().
-            and(RestrictionsGroup.group(query).
+            and(RestrictionsGroupImpl.group(query).
                  and(person.getName()).startsWith("Jef").
                  or(person.getName()).startsWith("John"));
 
@@ -132,14 +132,12 @@ public class ExamplesTest extends TypeSafeQueryTest {
 
     @Test
     public void testMultiFrom() {
-        Person parent = query.from(Person.class);
+        Person parent1 = query.from(Person.class);
+        Person parent2 = query.from(Person.class);
         
-        Relation childRelation = query.join(parent.getChildRelations());
-        Person child = query.join(childRelation.getChild());
-        
-        query.where(child.getName()).eq(parent.getName());
+        query.where(parent1.getName()).eq(parent2.getName());
 
-        validate(" from Person hobj1 join hobj1.childRelations hobj2 join hobj2.child hobj3 where hobj3.name = hobj1.name");
+        validate(" from Person hobj1, Person hobj2 where hobj1.name = hobj2.name");
     }
 
     @Test
@@ -183,7 +181,7 @@ public class ExamplesTest extends TypeSafeQueryTest {
         favoriteColorSQ.where(person.getId()).eq(personSQ.getId()).
                           and(favColor.getPropertyKey()).eq("FavColorKey");
 
-        query.wheret(favoriteColorSQ).eq("Blue");
+        query.whereString(favoriteColorSQ).eq("Blue");
         
         validate(" from Person hobj1 where (select hobj2.propertyValue from PersonProperty hobj2 where hobj1.id = hobj2.person.id and hobj2.propertyKey = ?) = ?",
                 "FavColorKey", "Blue");
@@ -246,7 +244,7 @@ public class ExamplesTest extends TypeSafeQueryTest {
     public void testUpperFunction() {
         Person person = query.from(Person.class);
         
-        query.wheret(query.function().upper(person.getName())).eq("TOM");
+        query.whereString(query.function().upper(person.getName())).eq("TOM");
 
         validate(" from Person hobj1 where upper(hobj1.name) = ?", "TOM");
         

--- a/src/test/java/be/shad/tsqb/test/SelectTests.java
+++ b/src/test/java/be/shad/tsqb/test/SelectTests.java
@@ -1,6 +1,6 @@
 package be.shad.tsqb.test;
 
-import static be.shad.tsqb.restrictions.RestrictionsGroup.group;
+import static be.shad.tsqb.restrictions.RestrictionsGroupImpl.group;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/src/test/java/be/shad/tsqb/test/WhereTests.java
+++ b/src/test/java/be/shad/tsqb/test/WhereTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import be.shad.tsqb.domain.House;
 import be.shad.tsqb.domain.Style;
 import be.shad.tsqb.query.TypeSafeSubQuery;
+import be.shad.tsqb.restrictions.RestrictionsGroup;
 
 public class WhereTests extends TypeSafeQueryTest {
 
@@ -60,4 +61,19 @@ public class WhereTests extends TypeSafeQueryTest {
 
         validate(" from House hobj1 where exists ( from House hobj2 where hobj2.name = hobj1.name and hobj2.id <> hobj1.id)");
     }
+
+    @Test
+    public void whereGroupMultiOrTest() {
+        House house = query.from(House.class);
+        
+        RestrictionsGroup group = query.whereGroup();
+        group.where(house.getStyle()).eq(Style.the1980s).
+                 or(house.getFloors()).gt(2);
+        
+        query.where(group).and(house.getName()).startsWith("Castle");
+        
+        validate(" from House hobj1 where (hobj1.style = ? or hobj1.floors > ?) and hobj1.name like ?", 
+                Style.the1980s, 2, "Castle%");
+    }
+    
 }

--- a/src/test/java/be/shad/tsqb/test/restrictions/RestrictionChainingTest.java
+++ b/src/test/java/be/shad/tsqb/test/restrictions/RestrictionChainingTest.java
@@ -1,6 +1,6 @@
 package be.shad.tsqb.test.restrictions;
 
-import static be.shad.tsqb.restrictions.RestrictionsGroup.group;
+import static be.shad.tsqb.restrictions.RestrictionsGroupImpl.group;
 import static java.lang.Boolean.FALSE;
 import static java.math.BigDecimal.ZERO;
 


### PR DESCRIPTION
- Renamed andt, andd, ande...., wheret, whered, ....
- Added interface for where restrictions, which is also implemented by the restrictionsgroup to allow more natural looking chaining (group.where(name).eq.... instead of group.and(..).eq)
