### PR TITLE
Added the option to convert a proxy to a subtype

### DIFF
--- a/src/main/java/be/shad/tsqb/helper/TypeSafeQueryHelper.java
+++ b/src/main/java/be/shad/tsqb/helper/TypeSafeQueryHelper.java
@@ -39,6 +39,14 @@ public interface TypeSafeQueryHelper {
      * calls to the given query.
      */
     <T> T createTypeSafeFromProxy(TypeSafeQueryInternal query, Class<T> clazz);
+
+    /**
+     * Get a new proxy for the same entity to gain access to the subtype methods
+     * 
+     * @throws IllegalArgumentException when hibernate doesn't know the subtype 
+     *         or the proxy is not a TypeSafeQueryProxy.
+     */
+    <S, T extends S> T createTypeSafeSubtypeProxy(TypeSafeQueryInternal query, S proxy, Class<T> subtype) throws IllegalArgumentException;
     
     /**
      * Uses the type safe query factory and adds method handling to delegate

--- a/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
+++ b/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
@@ -67,6 +67,14 @@ public interface TypeSafeQuery extends WhereRestrictions {
     <T> T from(Class<T> fromClass);
 
     /**
+     * Get a new proxy for the same entity to gain access to the subtype methods
+     * 
+     * @throws IllegalArgumentException when hibernate doesn't know the subtype 
+     *         or the proxy is not a TypeSafeQueryProxy.
+     */
+    <S, T extends S> T getAsSubtype(S proxy, Class<T> subtype) throws IllegalArgumentException;
+    
+    /**
      * Delegates to {@link #join(Collection, JoinType)} with {@link JoinType#Inner}
      */
     <T> T join(Collection<T> anyCollection);

--- a/src/test/java/be/shad/tsqb/domain/Apartment.java
+++ b/src/test/java/be/shad/tsqb/domain/Apartment.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Gert Wijns gert.wijns@gmail.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.shad.tsqb.domain;
+
+import java.math.BigDecimal;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "Apartment")
+public class Apartment extends Building {
+    private static final long serialVersionUID = 1759090813125728063L;
+
+    @Column
+    private BigDecimal revenue;
+
+    public BigDecimal getRevenue() {
+        return revenue;
+    }
+
+    public void setRevenue(BigDecimal revenue) {
+        this.revenue = revenue;
+    }
+    
+}

--- a/src/test/java/be/shad/tsqb/test/GetSuperTypeAsSubtypeAndBuildQueryTest.java
+++ b/src/test/java/be/shad/tsqb/test/GetSuperTypeAsSubtypeAndBuildQueryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Gert Wijns gert.wijns@gmail.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.shad.tsqb.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.hibernate.Query;
+import org.junit.Test;
+
+import be.shad.tsqb.domain.Apartment;
+import be.shad.tsqb.domain.Building;
+import be.shad.tsqb.domain.House;
+import be.shad.tsqb.domain.Town;
+import be.shad.tsqb.query.JoinType;
+import be.shad.tsqb.restrictions.RestrictionsGroupFactory;
+
+public class GetSuperTypeAsSubtypeAndBuildQueryTest extends TypeSafeQueryTest {
+
+    /**
+     * Assuming the property path doesn't need to be on the super type
+     * if it is on one of the subtypes of a hibernate types 
+     * with an @Inheritance annotation.
+     * <p>
+     * If this doesn't hold true, then creating this query will surely fail.
+     */
+    @Test
+    public void testHibernateAssumption() {
+        Query query = getSessionFactory().getCurrentSession().
+                createQuery("from Building b where b.revenue > 10.0");
+        query.list();
+    }
+
+    @Test
+    public void testGetInheritanceTypeAsSubtypeFrom() {
+        BigDecimal argument = new BigDecimal(10.0);
+        Building buildingProxy = query.from(Building.class);
+        
+        Apartment apartmentProxy = query.getAsSubtype(buildingProxy, Apartment.class);
+        query.where(apartmentProxy.getRevenue()).gt(argument);
+        
+        validate(" from Building hobj1 where hobj1.revenue > ?", argument);
+    }
+    
+    @Test
+    public void testGetInheritanceTypeAsSubtypeJoined() {
+        BigDecimal revenue = new BigDecimal(10.0);
+        TestDataCreator creator = new TestDataCreator(getSessionFactory());
+        Town town = creator.createTestTown();
+        House house1 = creator.createTestHouse(town, "Housy", 10);
+        House house2 = creator.createTestHouse(town, "Housy", 4);
+        Apartment apartment = creator.createTestApartment(town, revenue.add(new BigDecimal(1.0)));
+        
+        RestrictionsGroupFactory res = query.factories().getRestrictionsGroupFactory();
+        Town townProxy = query.from(Town.class);
+        Building buildingProxy = query.join(townProxy.getBuildings(), JoinType.Left);
+
+        Apartment apartmentProxy = query.getAsSubtype(buildingProxy, Apartment.class);
+        House houseProxy = query.getAsSubtype(buildingProxy, House.class);
+        query.or(
+            res.where(apartmentProxy.getRevenue()).gt(revenue),
+            res.where(houseProxy.getFloors()).gt(5));
+        query.selectValue(query.function().distinct(buildingProxy));
+        
+        validate("select distinct hobj2 from Town hobj1 "
+                + "left join hobj1.buildings hobj2 "
+                + "where hobj2.revenue > ? or hobj2.floors > ?", revenue, 5);
+        
+        assertEquals("Exected the first house and the apartment", 2, doQueryResult.size());
+        assertTrue("Expected house1 in the result.", doQueryResult.contains(house1));
+        assertFalse("Didn't expect house2 in the result.", doQueryResult.contains(house2));
+        assertTrue("Expected apartment in the result.", doQueryResult.contains(apartment));
+    }
+    
+}

--- a/src/test/java/be/shad/tsqb/test/TestDataCreator.java
+++ b/src/test/java/be/shad/tsqb/test/TestDataCreator.java
@@ -1,8 +1,12 @@
 package be.shad.tsqb.test;
 
+import java.math.BigDecimal;
+
 import org.hibernate.SessionFactory;
 
+import be.shad.tsqb.domain.Apartment;
 import be.shad.tsqb.domain.GeographicCoordinate;
+import be.shad.tsqb.domain.House;
 import be.shad.tsqb.domain.Town;
 import be.shad.tsqb.domain.people.Person;
 import be.shad.tsqb.domain.people.Relation;
@@ -45,6 +49,25 @@ public class TestDataCreator {
         person.setTown(town);
         sessionFactory.getCurrentSession().save(person);
         return person;
+    }
+
+    public House createTestHouse(Town town, String name, int floors) {
+        House house = new House();
+        house.setTown(town);
+        house.setId(idGen++);
+        house.setName(name);
+        house.setFloors(floors);
+        sessionFactory.getCurrentSession().save(house);
+        return house;
+    }
+
+    public Apartment createTestApartment(Town town, BigDecimal revenue) {
+        Apartment apartment = new Apartment();
+        apartment.setTown(town);
+        apartment.setId(idGen++);
+        apartment.setRevenue(revenue);
+        sessionFactory.getCurrentSession().save(apartment);
+        return apartment;
     }
 
 }

--- a/src/test/java/be/shad/tsqb/test/TypeSafeQueryTest.java
+++ b/src/test/java/be/shad/tsqb/test/TypeSafeQueryTest.java
@@ -18,6 +18,7 @@ package be.shad.tsqb.test;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,6 +42,7 @@ public class TypeSafeQueryTest {
     private SessionFactory sessionFactory;
     private TypeSafeQueryHelperImpl helper;
     protected TypeSafeRootQuery query;
+    protected List<?> doQueryResult;
 
     /**
      * Initialize the sessionFactory and helper.
@@ -98,7 +100,7 @@ public class TypeSafeQueryTest {
         
         // call the list, this is the moment of truth:
         query.setResultTransformer(hqlQuery.getResultTransformer());
-        query.list();
+        doQueryResult = query.list();
         
         // return for additional checks:
         return hqlQuery;

--- a/src/test/resources/be/shad/tsqb/tests/hibernate.cfg.xml
+++ b/src/test/resources/be/shad/tsqb/tests/hibernate.cfg.xml
@@ -42,6 +42,7 @@
         <mapping class="be.shad.tsqb.domain.Town" />
         <mapping class="be.shad.tsqb.domain.TownProperty" />
         <mapping class="be.shad.tsqb.domain.Building" />
+        <mapping class="be.shad.tsqb.domain.Apartment" />
         <mapping class="be.shad.tsqb.domain.House" />
         <mapping class="be.shad.tsqb.domain.School" />
         <mapping class="be.shad.tsqb.domain.Product" />


### PR DESCRIPTION
- The proxy can be converted to a subtype to make the
  properties of the subtype available, this is supported by hibernate
  and will automatically add left outer joins to the subtypes.
  Use with care!
