### PR TITLE
Added NullTypeSafeValue to be able to select a null value

### DIFF
--- a/src/main/java/be/shad/tsqb/values/NullTypeSafeValue.java
+++ b/src/main/java/be/shad/tsqb/values/NullTypeSafeValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Gert Wijns gert.wijns@gmail.com
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package be.shad.tsqb.values;
+
+import be.shad.tsqb.query.TypeSafeQuery;
+import be.shad.tsqb.query.copy.CopyContext;
+import be.shad.tsqb.query.copy.Copyable;
+
+/**
+ * Not statically available because the .select() 
+ * should register the value in the relevant query.
+ * <p>
+ * This is the only way to select null in the query.
+ */
+public final class NullTypeSafeValue<T> extends TypeSafeValueImpl<T> {
+
+    protected NullTypeSafeValue(CopyContext context, NullTypeSafeValue<T> original) {
+        super(context, original);
+    }
+    
+    public NullTypeSafeValue(TypeSafeQuery query, Class<T> valueType) {
+        super(query, valueType);
+    }
+
+    @Override
+    public HqlQueryValue toHqlQueryValue(HqlQueryBuilderParams params) {
+        // suggested on stackoverflow to select null:
+        return new HqlQueryValueImpl("cast(null as char)");
+    }
+
+    @Override
+    public Copyable copy(CopyContext context) {
+        return new NullTypeSafeValue<>(context, this);
+    }
+}

--- a/src/test/java/be/shad/tsqb/test/WithDataTest.java
+++ b/src/test/java/be/shad/tsqb/test/WithDataTest.java
@@ -15,10 +15,14 @@
  */
 package be.shad.tsqb.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import org.junit.Test;
 
 import be.shad.tsqb.domain.people.Person;
 import be.shad.tsqb.dto.PersonDto;
+import be.shad.tsqb.values.NullTypeSafeValue;
 
 public class WithDataTest extends TypeSafeQueryTest {
 
@@ -31,6 +35,22 @@ public class WithDataTest extends TypeSafeQueryTest {
         PersonDto selectProxy = query.select(PersonDto.class);
         selectProxy.setId(fromProxy.getId());
         validate("select hobj1.id as id from Person hobj1");
+    }
+    
+    @Test
+    public void testSelectNull() {
+        TestDataCreator creator = new TestDataCreator(getSessionFactory());
+        creator.createTestPerson(creator.createTestTown(), "Josh");
+        
+        Person personProxy = query.from(Person.class);
+        PersonDto selectProxy = query.select(PersonDto.class);
+        selectProxy.setId(new NullTypeSafeValue<>(query, Long.class).select());
+        selectProxy.setThePersonsName(personProxy.getName());
+        validate("select cast(null as char) as id, hobj1.name as thePersonsName from Person hobj1");
+        assertEquals(1, doQueryResult.size());
+        PersonDto result = (PersonDto) doQueryResult.get(0);
+        assertNull(result.getId());
+        assertEquals(result.getThePersonsName(), "Josh");
     }
     
 }


### PR DESCRIPTION
The use case is probably very narrow, can be used when using
a factory which generates some type safe value with an optional
null value in some case.
