### PR TITLE
TSQB-51: Moved logic to the abstract class

### DIFF
--- a/src/main/java/be/shad/tsqb/query/AbstractTypeSafeQuery.java
+++ b/src/main/java/be/shad/tsqb/query/AbstractTypeSafeQuery.java
@@ -53,6 +53,7 @@ import be.shad.tsqb.values.CustomTypeSafeValue;
 import be.shad.tsqb.values.DirectTypeSafeStringValue;
 import be.shad.tsqb.values.DirectTypeSafeValue;
 import be.shad.tsqb.values.HqlQueryBuilderParams;
+import be.shad.tsqb.values.HqlQueryBuilderParamsImpl;
 import be.shad.tsqb.values.HqlQueryValue;
 import be.shad.tsqb.values.HqlQueryValueImpl;
 import be.shad.tsqb.values.ReferenceTypeSafeValue;
@@ -745,6 +746,16 @@ public abstract class AbstractTypeSafeQuery implements TypeSafeQuery, TypeSafeQu
             throw new IllegalStateException(String.format("[%d] invocations were "
                     + "made before transforming it to a value.", invocations.size()));
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toFormattedString() {
+        HqlQueryBuilderParamsImpl params = new HqlQueryBuilderParamsImpl();
+        params.setBuildingForDisplay(true);
+        return toHqlQuery(params).toFormattedString();
     }
 
     /**

--- a/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
+++ b/src/main/java/be/shad/tsqb/query/TypeSafeQuery.java
@@ -295,6 +295,11 @@ public interface TypeSafeQuery extends TypeSafeQueryJoin, WhereRestrictions, Hav
     <T> T getByHqlAlias(String alias);
 
     /**
+     * @return a formatted string representation of the resulting hql
+     */
+    String toFormattedString();
+
+    /**
      * The predicate to use if no more specific predicate was set on the restriction.
      * May be null when not applicable.
      */

--- a/src/main/java/be/shad/tsqb/query/TypeSafeRootQuery.java
+++ b/src/main/java/be/shad/tsqb/query/TypeSafeRootQuery.java
@@ -72,11 +72,6 @@ public interface TypeSafeRootQuery extends TypeSafeQuery {
     HqlQuery toHqlQuery();
 
     /**
-     * @return a formatted string representation of the resulting hql
-     */
-    String toFormattedString();
-
-    /**
      * Can be used when not selecting into a result type,
      * or when selecting a single value in a subquery.
      * <p>

--- a/src/main/java/be/shad/tsqb/query/TypeSafeRootQueryImpl.java
+++ b/src/main/java/be/shad/tsqb/query/TypeSafeRootQueryImpl.java
@@ -445,16 +445,6 @@ public class TypeSafeRootQueryImpl extends AbstractTypeSafeQuery implements Type
      * {@inheritDoc}
      */
     @Override
-    public String toFormattedString() {
-        HqlQueryBuilderParamsImpl params = new HqlQueryBuilderParamsImpl();
-        params.setBuildingForDisplay(true);
-        return super.toHqlQuery(params).toFormattedString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public TypeSafeNameds named() {
         return namedObjects;
     }


### PR DESCRIPTION
- moved the to formatted string so it's possible
  to get the hql string from just the subquery
  for debugging purposes