### PR TITLE
TSBQ-43: Drop the aliases for the actual query

### DIFF
--- a/src/main/java/be/shad/tsqb/selection/TypeSafeQueryProjections.java
+++ b/src/main/java/be/shad/tsqb/selection/TypeSafeQueryProjections.java
@@ -48,6 +48,7 @@ public class TypeSafeQueryProjections implements HqlQueryBuilder {
     private String mapSelectionKeyForNextProjection;
     private Class<?> resultClass;
     private Boolean selectingIntoDto;
+    private boolean includeAliases;
 
     public TypeSafeQueryProjections(TypeSafeQueryInternal query) {
         this.query = query;
@@ -57,6 +58,7 @@ public class TypeSafeQueryProjections implements HqlQueryBuilder {
         this.transformerForNextProjection = context.getOrOriginal(original.transformerForNextProjection);
         this.mapSelectionKeyForNextProjection = original.mapSelectionKeyForNextProjection;
         this.resultClass = original.resultClass;
+        this.includeAliases = original.includeAliases;
         for(TypeSafeValueProjection projection: original.projections) {
             projections.add(context.get(projection));
         }
@@ -68,6 +70,10 @@ public class TypeSafeQueryProjections implements HqlQueryBuilder {
 
     public Class<?> getResultClass() {
         return resultClass;
+    }
+
+    public void setIncludeAliases(boolean includeAliases) {
+        this.includeAliases = includeAliases;
     }
 
     public Deque<TypeSafeValueProjection> getProjections() {
@@ -206,7 +212,9 @@ public class TypeSafeQueryProjections implements HqlQueryBuilder {
             TypeSafeQuerySelectionProxyData selectionData = projection.getSelectionData();
             if (selectionData != null) {
                 selectionDatas.add(selectionData);
-                alias = " as " + selectionData.getAlias();
+                if (params.isBuildingForDisplay() || includeAliases) {
+                    alias = " as " + selectionData.getAlias();
+                }
             }
             transformers.add(projection.getTransformer());
             hasTransformer = hasTransformer || projection.getTransformer() != null;

--- a/src/test/java/be/shad/tsqb/test/TypeSafeQueryTest.java
+++ b/src/test/java/be/shad/tsqb/test/TypeSafeQueryTest.java
@@ -42,6 +42,7 @@ import be.shad.tsqb.dao.TypeSafeQueryDaoImpl;
 import be.shad.tsqb.helper.TypeSafeQueryHelperImpl;
 import be.shad.tsqb.hql.HqlQuery;
 import be.shad.tsqb.query.TypeSafeRootQuery;
+import be.shad.tsqb.query.TypeSafeRootQueryInternal;
 import be.shad.tsqb.values.HqlQueryValue;
 
 public class TypeSafeQueryTest {
@@ -84,6 +85,7 @@ public class TypeSafeQueryTest {
     @Before
     public void initialize() {
         query = typeSafeQueryDao.createQuery();
+        ((TypeSafeRootQueryInternal) query).getProjections().setIncludeAliases(true);
         sessionFactory.getCurrentSession().beginTransaction();
     }
 


### PR DESCRIPTION
- tsqb doesn't need them to properly parse the query result list
- it's still possible to set to use aliases, the default will not include aliases
- this will generate shorted hql queries and will be slightly faster (no . replace to _ in the alias generation)